### PR TITLE
fix quaternion slerp again

### DIFF
--- a/src/main/java/com/jme3/math/Quaternion.java
+++ b/src/main/java/com/jme3/math/Quaternion.java
@@ -829,15 +829,23 @@ public final class Quaternion implements Cloneable, java.io.Serializable {
 			result = -result;
 		}
 
-		// Get the angle between the 2 quaternions,
-		// and then store the sin() of that angle
-		float theta = FastMath.acos(result);
-		float invSinTheta = 1f / FastMath.sin(theta);
+		// Set the first and second scale for the interpolation
+		float scale0 = 1 - t;
+		float scale1 = t;
 
-		// Calculate the scale for q1 and q2, according to the angle and
-		// its sine value
-		float scale0 = FastMath.sin((1 - t) * theta) * invSinTheta;
-		float scale1 = FastMath.sin((t * theta)) * invSinTheta;
+		// Check if the angle between the 2 quaternions was big enough to
+		// warrant such calculations
+		if ((1 - result) > 0.0f) {
+			// Get the angle between the 2 quaternions,
+			// and then store the sin() of that angle
+			float theta = FastMath.acos(result);
+			float invSinTheta = 1f / FastMath.sin(theta);
+
+			// Calculate the scale for q1 and q2, according to the angle and
+			// its sine value
+			scale0 = FastMath.sin((1 - t) * theta) * invSinTheta;
+			scale1 = FastMath.sin((t * theta)) * invSinTheta;
+		}
 
 		// Calculate the x, y, z and w values for the quaternion by using a
 		// special
@@ -874,15 +882,23 @@ public final class Quaternion implements Cloneable, java.io.Serializable {
 			result = -result;
 		}
 
-		// Get the angle between the 2 quaternions, and then store the sin()
-		// of that angle
-		float theta = FastMath.acos(result);
-		float invSinTheta = 1f / FastMath.sin(theta);
+		// Set the first and second scale for the interpolation
+		float scale0 = 1 - changeAmnt;
+		float scale1 = changeAmnt;
 
-		// Calculate the scale for q1 and q2, according to the angle and
-		// its sine value
-		float scale0 = FastMath.sin((1 - changeAmnt) * theta) * invSinTheta;
-		float scale1 = FastMath.sin((changeAmnt * theta)) * invSinTheta;
+		// Check if the angle between the 2 quaternions was big enough to
+		// warrant such calculations
+		if ((1 - result) > 0.0f) {
+			// Get the angle between the 2 quaternions,
+			// and then store the sin() of that angle
+			float theta = FastMath.acos(result);
+			float invSinTheta = 1f / FastMath.sin(theta);
+
+			// Calculate the scale for q1 and q2, according to the angle and
+			// its sine value
+			scale0 = FastMath.sin((1 - changeAmnt) * theta) * invSinTheta;
+			scale1 = FastMath.sin((changeAmnt * theta)) * invSinTheta;
+		}
 
 		// Calculate the x, y, z and w values for the quaternion by using a
 		// special


### PR DESCRIPTION
While removing the check if `((1 - result) > 0.1f)` got rid of the snapping problem, it indeed introduced problems when the angle between the 2 quaternions was too small. (NaN using Quaternion.toString()) https://cdn.discordapp.com/attachments/948579740225261598/978377254566510643/unknown.png

Reintroducing the check but checking if `> 0.0f` instead of `> 0.1f` seems to get rid of both problems.