### PR TITLE
New better slerp() methods. Added angleBetween() and negated()

### DIFF
--- a/src/main/java/com/jme3/math/Quaternion.java
+++ b/src/main/java/com/jme3/math/Quaternion.java
@@ -847,14 +847,13 @@ public final class Quaternion implements Cloneable, java.io.Serializable {
 			this.y = iMag * sy;
 			this.z = iMag * sz;
 
-		} else if (t < 0.5f) {
-			// this == q1, no need to do anything.
-		} else {
+		} else if (t >= 0.5f) {
 			this.w = q2.w;
 			this.x = q2.x;
 			this.y = q2.y;
 			this.z = q2.z;
 		}
+		// else this == q1, no need to do anything.
 
 		return this;
 	}

--- a/src/main/java/com/jme3/math/Quaternion.java
+++ b/src/main/java/com/jme3/math/Quaternion.java
@@ -816,7 +816,7 @@ public final class Quaternion implements Cloneable, java.io.Serializable {
 		return ang;
 	}
 
-	public Quaternion pureSlerpThis(Quaternion q2, float t) {
+	public Quaternion pureSlerpLocal(Quaternion q2, float t) {
 		// make it nice and symmetrical
 		Quaternion q1 = this;
 
@@ -866,10 +866,10 @@ public final class Quaternion implements Cloneable, java.io.Serializable {
 
 	/**
 	 * @deprecated
-	 *	Direct call to {@link #slerpThis()}.
+	 *	Direct call to {@link #slerpLocal()}.
 	 */
 	public Quaternion slerp(Quaternion q2, float t) {
-		return this.slerpThis(q2, t);
+		return this.slerpLocal(q2, t);
 	}
 
 	/**
@@ -878,22 +878,22 @@ public final class Quaternion implements Cloneable, java.io.Serializable {
 	 * @param q2 Final interpolation value
 	 * @param t The amount diffrence
 	 */
-	public Quaternion slerpThis(Quaternion q2, float t) {
+	public Quaternion slerpLocal(Quaternion q2, float t) {
 		// make it nice and symmetrical
 		Quaternion q1 = this;
 
 		float rw = q1.w*q2.w + q1.x*q2.x + q1.y*q2.y + q1.z*q2.z;
 		
 		if (rw < 0) {
-			return this.pureSlerpThis(q2.negated(), t);
+			return this.pureSlerpLocal(q2.negated(), t);
 		} else {
-			return this.pureSlerpThis(q2, t);
+			return this.pureSlerpLocal(q2, t);
 		}
 	}
 
 
 	public Quaternion pureSlerp(Quaternion q1, Quaternion q2, float t) {
-		return q1.clone().pureSlerpThis(q2, t);
+		return q1.clone().pureSlerpLocal(q2, t);
 	}
 
 	/**
@@ -908,9 +908,9 @@ public final class Quaternion implements Cloneable, java.io.Serializable {
 		float rw = q1.w*q2.w + q1.x*q2.x + q1.y*q2.y + q1.z*q2.z;
 		
 		if (rw < 0) {
-			return q1.clone().pureSlerpThis(q2.negated(), t);
+			return q1.clone().pureSlerpLocal(q2.negated(), t);
 		} else {
-			return q1.clone().pureSlerpThis(q2, t);
+			return q1.clone().pureSlerpLocal(q2, t);
 		}
 	}
 

--- a/src/main/java/com/jme3/math/Quaternion.java
+++ b/src/main/java/com/jme3/math/Quaternion.java
@@ -811,9 +811,7 @@ public final class Quaternion implements Cloneable, java.io.Serializable {
 
 		// compute cosine and sine of the angle between
 		// do so in a numerically stable way
-		float ang = FastMath.atan2(FastMath.sqrt(x * x + y * y + z * z), w);
-
-		return ang;
+		return FastMath.atan2(FastMath.sqrt(x * x + y * y + z * z), w);
 	}
 
 	public Quaternion pureSlerpLocal(Quaternion q2, float t) {
@@ -850,10 +848,7 @@ public final class Quaternion implements Cloneable, java.io.Serializable {
 			this.z = iMag * sz;
 
 		} else if (t < 0.5f) {
-			// this.w = q1.w;
-			// this.x = q1.x;
-			// this.y = q1.y;
-			// this.z = q1.z;
+			// this == q1, no need to do anything.
 		} else {
 			this.w = q2.w;
 			this.x = q2.x;
@@ -908,9 +903,9 @@ public final class Quaternion implements Cloneable, java.io.Serializable {
 		float rw = q1.w * q2.w + q1.x * q2.x + q1.y * q2.y + q1.z * q2.z;
 
 		if (rw < 0) {
-			return set(q1).pureSlerpLocal(q2.negate(), t);
+			return pureSlerp(q1, q2.negate(), t);
 		} else {
-			return set(q1).pureSlerpLocal(q2, t);
+			return pureSlerp(q1, q2, t);
 		}
 	}
 
@@ -1493,7 +1488,7 @@ public final class Quaternion implements Cloneable, java.io.Serializable {
 	}
 
 	/**
-	 * <code>negate</code> inverts the values of the quaternion. and returns it
+	 * <code>negateLocal</code> inverts the values of the quaternion and returns it.
 	 */
 	public Quaternion negateLocal() {
 		x = -x;
@@ -1504,7 +1499,7 @@ public final class Quaternion implements Cloneable, java.io.Serializable {
 	}
 
 	/**
-	 * <code>negate</code> returns the negated quaternion.
+	 * <code>negate</code> returns a negated copy of the quaternion.
 	 */
 	public Quaternion negate() {
 		return new Quaternion(-x, -y, -z, -w);

--- a/src/main/java/com/jme3/math/Quaternion.java
+++ b/src/main/java/com/jme3/math/Quaternion.java
@@ -821,13 +821,13 @@ public final class Quaternion implements Cloneable, java.io.Serializable {
 		Quaternion q1 = this;
 
 		// get q2 relative to q1
-		// float rw = q1.w * q2.w + q1.x * q2.x + q1.y * q2.y + q1.z * q2.z;
+		float rw = q1.w * q2.w + q1.x * q2.x + q1.y * q2.y + q1.z * q2.z;
 		float rx = q1.w * q2.x - q1.x * q2.w - q1.y * q2.z + q1.z * q2.y;
 		float ry = q1.w * q2.y + q1.x * q2.z - q1.y * q2.w - q1.z * q2.x;
 		float rz = q1.w * q2.z - q1.x * q2.y + q1.y * q2.x - q1.z * q2.w;
 
 		// compute theta robustly
-		float theta = FastMath.atan2(FastMath.sqrt(rx * rx + ry * ry + rz * rz), w);
+		float theta = FastMath.atan2(FastMath.sqrt(rx * rx + ry * ry + rz * rz), rw);
 
 		// compute interpolation variables
 		float s0 = FastMath.sin((1.0f - t) * theta);

--- a/src/main/java/com/jme3/math/Quaternion.java
+++ b/src/main/java/com/jme3/math/Quaternion.java
@@ -803,11 +803,11 @@ public final class Quaternion implements Cloneable, java.io.Serializable {
 		return angle;
 	}
 
-	public float angleBetween(Quaternion q1, Quaternion q2) {
-		float w = q1.w * q2.w + q1.x * q2.x + q1.y * q2.y + q1.z * q2.z;
-		float x = q1.w * q2.x - q1.x * q2.w - q1.y * q2.z + q1.z * q2.y;
-		float y = q1.w * q2.y + q1.x * q2.z - q1.y * q2.w - q1.z * q2.x;
-		float z = q1.w * q2.z - q1.x * q2.y + q1.y * q2.x - q1.z * q2.w;
+	public float angleBetween(Quaternion q2) {
+		float w = this.w * q2.w + this.x * q2.x + this.y * q2.y + this.z * q2.z;
+		float x = this.w * q2.x - this.x * q2.w - this.y * q2.z + this.z * q2.y;
+		float y = this.w * q2.y + this.x * q2.z - this.y * q2.w - this.z * q2.x;
+		float z = this.w * q2.z - this.x * q2.y + this.y * q2.x - this.z * q2.w;
 
 		// compute cosine and sine of the angle between
 		// do so in a numerically stable way
@@ -872,7 +872,8 @@ public final class Quaternion implements Cloneable, java.io.Serializable {
 	}
 
 	/**
-	 * Sets the values of this quaternion to the slerp from itself to q2 by t
+	 * Sets the values of this normalized quaternion from itself to the
+	 * normalized quaternion q2 by t
 	 *
 	 * @param q2 Final interpolation value
 	 * @param t The amount diffrence
@@ -884,7 +885,7 @@ public final class Quaternion implements Cloneable, java.io.Serializable {
 		float rw = q1.w * q2.w + q1.x * q2.x + q1.y * q2.y + q1.z * q2.z;
 
 		if (rw < 0) {
-			return this.pureSlerpLocal(q2.normalizeLocal().negated(), t);
+			return this.pureSlerpLocal(q2.negate(), t);
 		} else {
 			return this.pureSlerpLocal(q2, t);
 		}
@@ -892,12 +893,12 @@ public final class Quaternion implements Cloneable, java.io.Serializable {
 
 
 	public Quaternion pureSlerp(Quaternion q1, Quaternion q2, float t) {
-		return q1.clone().pureSlerpLocal(q2, t);
+		return set(q1).pureSlerpLocal(q2, t);
 	}
 
 	/**
 	 * <code>slerp</code> sets this quaternion's value as an interpolation
-	 * between two other quaternions.
+	 * between two other normalized quaternions.
 	 *
 	 * @param q1 the first quaternion.
 	 * @param q2 the second quaternion.
@@ -907,9 +908,9 @@ public final class Quaternion implements Cloneable, java.io.Serializable {
 		float rw = q1.w * q2.w + q1.x * q2.x + q1.y * q2.y + q1.z * q2.z;
 
 		if (rw < 0) {
-			return q1.normalized().pureSlerpLocal(q2.normalized().negated(), t);
+			return set(q1).pureSlerpLocal(q2.negate(), t);
 		} else {
-			return q1.normalized().pureSlerpLocal(q2.normalized(), t);
+			return set(q1).pureSlerpLocal(q2, t);
 		}
 	}
 
@@ -1425,7 +1426,7 @@ public final class Quaternion implements Cloneable, java.io.Serializable {
 	/**
 	 * <code>normalize</code> returns the normalized <code>Quaternion</code>.
 	 */
-	public Quaternion normalized() {
+	public Quaternion normalize() {
 		Quaternion q = this.clone();
 
 		float n = FastMath.invSqrt(q.norm());
@@ -1492,21 +1493,20 @@ public final class Quaternion implements Cloneable, java.io.Serializable {
 	}
 
 	/**
-	 * <code>negate</code> inverts the values of the quaternion.
-	 *
+	 * <code>negate</code> inverts the values of the quaternion. and returns it
 	 */
-	public void negate() {
-		x *= -1;
-		y *= -1;
-		z *= -1;
-		w *= -1;
+	public Quaternion negateLocal() {
+		x = -x;
+		y = -y;
+		z = -z;
+		w = -w;
+		return this;
 	}
 
 	/**
 	 * <code>negate</code> returns the negated quaternion.
-	 *
 	 */
-	public Quaternion negated() {
+	public Quaternion negate() {
 		return new Quaternion(-x, -y, -z, -w);
 	}
 

--- a/src/main/java/com/jme3/math/Quaternion.java
+++ b/src/main/java/com/jme3/math/Quaternion.java
@@ -804,14 +804,14 @@ public final class Quaternion implements Cloneable, java.io.Serializable {
 	}
 
 	public float angleBetween(Quaternion q1, Quaternion q2) {
-		float w = q1.w*q2.w + q1.x*q2.x + q1.y*q2.y + q1.z*q2.z;
-		float x = q1.w*q2.x - q1.x*q2.w - q1.y*q2.z + q1.z*q2.y;
-		float y = q1.w*q2.y + q1.x*q2.z - q1.y*q2.w - q1.z*q2.x;
-		float z = q1.w*q2.z - q1.x*q2.y + q1.y*q2.x - q1.z*q2.w;
+		float w = q1.w * q2.w + q1.x * q2.x + q1.y * q2.y + q1.z * q2.z;
+		float x = q1.w * q2.x - q1.x * q2.w - q1.y * q2.z + q1.z * q2.y;
+		float y = q1.w * q2.y + q1.x * q2.z - q1.y * q2.w - q1.z * q2.x;
+		float z = q1.w * q2.z - q1.x * q2.y + q1.y * q2.x - q1.z * q2.w;
 
 		// compute cosine and sine of the angle between
 		// do so in a numerically stable way
-		float ang = FastMath.atan2(FastMath.sqrt(x*x + y*y + z*z), w);
+		float ang = FastMath.atan2(FastMath.sqrt(x * x + y * y + z * z), w);
 
 		return ang;
 	}
@@ -865,8 +865,7 @@ public final class Quaternion implements Cloneable, java.io.Serializable {
 	}
 
 	/**
-	 * @deprecated
-	 *	Direct call to {@link #slerpLocal()}.
+	 * @deprecated Direct call to {@link #slerpLocal()}.
 	 */
 	public Quaternion slerp(Quaternion q2, float t) {
 		return this.slerpLocal(q2, t);
@@ -882,10 +881,10 @@ public final class Quaternion implements Cloneable, java.io.Serializable {
 		// make it nice and symmetrical
 		Quaternion q1 = this;
 
-		float rw = q1.w*q2.w + q1.x*q2.x + q1.y*q2.y + q1.z*q2.z;
-		
+		float rw = q1.w * q2.w + q1.x * q2.x + q1.y * q2.y + q1.z * q2.z;
+
 		if (rw < 0) {
-			return this.pureSlerpLocal(q2.negated(), t);
+			return this.pureSlerpLocal(q2.normalizeLocal().negated(), t);
 		} else {
 			return this.pureSlerpLocal(q2, t);
 		}
@@ -905,12 +904,12 @@ public final class Quaternion implements Cloneable, java.io.Serializable {
 	 * @param t the amount to interpolate between the two quaternions.
 	 */
 	public Quaternion slerp(Quaternion q1, Quaternion q2, float t) {
-		float rw = q1.w*q2.w + q1.x*q2.x + q1.y*q2.y + q1.z*q2.z;
-		
+		float rw = q1.w * q2.w + q1.x * q2.x + q1.y * q2.y + q1.z * q2.z;
+
 		if (rw < 0) {
-			return q1.clone().pureSlerpLocal(q2.negated(), t);
+			return q1.normalized().pureSlerpLocal(q2.normalized().negated(), t);
 		} else {
-			return q1.clone().pureSlerpLocal(q2, t);
+			return q1.normalized().pureSlerpLocal(q2.normalized(), t);
 		}
 	}
 
@@ -1410,23 +1409,9 @@ public final class Quaternion implements Cloneable, java.io.Serializable {
 		return w * w + x * x + y * y + z * z;
 	}
 
-	// /**
-	// * <code>normalize</code> normalizes the current <code>Quaternion</code>
-	// * @deprecated The naming of this method doesn't follow convention.
-	// * Please use {@link Quaternion#normalizeLocal() } instead.
-	// */
-	// @Deprecated
-	// public void normalize() {
-	// float n = FastMath.invSqrt(norm());
-	// x *= n;
-	// y *= n;
-	// z *= n;
-	// w *= n;
-	// }
-
 	/**
-	 * <code>normalize</code> normalizes the current <code>Quaternion</code>.
-	 * The result is stored internally.
+	 * <code>normalizeLocal</code> normalizes the current
+	 * <code>Quaternion</code>. The result is stored internally.
 	 */
 	public Quaternion normalizeLocal() {
 		float n = FastMath.invSqrt(norm());
@@ -1435,6 +1420,20 @@ public final class Quaternion implements Cloneable, java.io.Serializable {
 		z *= n;
 		w *= n;
 		return this;
+	}
+
+	/**
+	 * <code>normalize</code> returns the normalized <code>Quaternion</code>.
+	 */
+	public Quaternion normalized() {
+		Quaternion q = this.clone();
+
+		float n = FastMath.invSqrt(q.norm());
+		q.x *= n;
+		q.y *= n;
+		q.z *= n;
+		q.w *= n;
+		return q;
 	}
 
 	/**
@@ -1508,11 +1507,7 @@ public final class Quaternion implements Cloneable, java.io.Serializable {
 	 *
 	 */
 	public Quaternion negated() {
-		x *= -1;
-		y *= -1;
-		z *= -1;
-		w *= -1;
-		return this;
+		return new Quaternion(-x, -y, -z, -w);
 	}
 
 	/**


### PR DESCRIPTION
- Replace the old quaternion `slerp()` methods by ones written by AxisAngle.
- Added `pureSlerp` methods, to slerp past 180 degrees.
- Rename `Quaternion.slerp(q2, t)` to `Quaternion.slerpLocal(q2, t)`. Supports old naming with `@deprecated`
- Added `Quaternion.negated()`, `Quaternion.normalized()` and `Quaternion.angleBetween()`